### PR TITLE
Reduced-Motion-Unterstützung für Intro-Animation

### DIFF
--- a/Resources/Private/JavaScript/signalwerkFrontend.js
+++ b/Resources/Private/JavaScript/signalwerkFrontend.js
@@ -56,8 +56,14 @@ function pad(n, width, z) {
     }
     var isTimeToPlay = lastPlayed + delta < Date.now();
 
+    var prefersReducedMotion =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
     if ($body.hasClass("noBackground")) {
-      if (isTimeToPlay) {
+      if (prefersReducedMotion) {
+        $body.addClass("no-animation");
+      } else if (isTimeToPlay) {
         store.setItem("animationLastPlayed", Date.now());
       } else {
         $body.addClass("no-animation");


### PR DESCRIPTION
## Was

Die Intro-Animation (Hintergrund-Animation basierend auf der Signaletik des Kantons Zürich) berücksichtigt neu die Betriebssystem-Einstellung `prefers-reduced-motion: reduce`.

## Warum

Die vollflächige Animation läuft bei jedem Seitenaufruf und kann für Nutzer:innen mit Bewegungsempfindlichkeit störend oder problematisch sein. Bisher gab es keine Möglichkeit, sie über die System-Einstellung zu deaktivieren (Barrierefreiheit, WCAG 2.3.3 «Animation from Interactions»).

## Wie

In `Resources/Private/JavaScript/signalwerkFrontend.js` wird beim Laden geprüft, ob `prefers-reduced-motion: reduce` aktiv ist. Falls ja, wird die bereits bestehende Klasse `no-animation` auf `<body>` gesetzt, welche die Animation über die vorhandene CSS-Regel in `background.scss` (`body.noBackground.no-animation:after { content: none; }`) unterdrückt.

- Wiederverwendung des bestehenden `no-animation`-Mechanismus – keine neuen Styles nötig.
- `window.matchMedia`-Guard für ältere Browser ohne Media-Query-Support.
- Prüfung erfolgt einmalig beim Laden (ausreichend, da die Animation nur beim Seitenaufruf startet).

> Hinweis: Es handelt sich um eine Quelldatei unter `Resources/Private/JavaScript`. Vor dem Ausliefern muss der Frontend-Build (Webpack) ausgeführt werden.